### PR TITLE
Added checks for circular dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,3 @@ console.log(config);
 - a config can extend another config by specifying `_extends: '<name of other config>'`. Properties in the extending config overwrite properties in the extended config. There's no maximum to the amount of inheritance levels.
 - configs are deeply merged using [lodash.merge](https://lodash.com/docs#merge).
 - this module throws errors because your process should die when it fails to load its configuration. If you disagree (for your specific use case), don't use this module or `try-catch` your way out of it.
-
-## warning
-There's currently no protection against indirectly self-referencing configs, e.g. `A -> B -> A`. If you setup your configs like this, your process will crash because it will get into an infinite loop.

--- a/index.js
+++ b/index.js
@@ -67,9 +67,6 @@ function processConfigs(foundConfigs) {
 // NOTE: not the most efficient because sub-chains might be walked more than once
 //       but who cares, this runs once per process
 //       and who has more than a bunch of config files anyway
-// NOTE: this function prevents immediate self-referencing but not indirect
-//       so A -> A throws an error, but A -> B -> A doesn't
-//       and will probably just halt your process from continuing (AKA infinite loop)
 function processConfig(configs, name) {
     var config = configs[name];
     if (!config._extends) {
@@ -78,6 +75,18 @@ function processConfig(configs, name) {
     if (config._extends === name) {
         throw new Error('config cannot extend itself');
     }
+
+    // check for circular dependencies
+    var visited = [];
+    var tempconfig = config;
+    while (tempconfig._extends) {
+        if (visited.indexOf(tempconfig._extends) !== -1) {
+            throw new Error('circular dependencies detected in chain ' + JSON.stringify(visited));
+        }
+        visited.push(tempconfig._extends);
+        tempconfig = configs[tempconfig._extends];
+    }
+
     var extendedConfig = processConfig(configs, config._extends);
     return mergeConfigs(extendedConfig, config);
 }

--- a/test/circular_config/d.js
+++ b/test/circular_config/d.js
@@ -1,0 +1,10 @@
+module.exports = {
+    _extends: 'e',
+    name: 'd',
+    something: {
+        anything: {
+            arr: [4, 5, 6],
+        },
+        else: {},
+    },
+};

--- a/test/circular_config/e.js
+++ b/test/circular_config/e.js
@@ -1,0 +1,10 @@
+module.exports = {
+    _extends: 'f',
+    name: 'e',
+    something: {
+        anything: {
+            arr: [4, 5, 6],
+        },
+        else: {},
+    },
+};

--- a/test/circular_config/f.js
+++ b/test/circular_config/f.js
@@ -1,0 +1,11 @@
+module.exports = {
+    _extends: 'd',
+    name: 'f',
+    something: {
+        anything: {
+            arr: [4, 5, 6],
+        },
+        else: {},
+    },
+    apple: 'pie',
+};

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,6 @@
 var _ = require('lodash');
 var expect = require('chai').expect;
+var assert = require('chai').assert;
 
 var configuratoror = require('../index.js');
 
@@ -46,5 +47,12 @@ describe('configuratoror', function () {
         expect(c.something.else).to.eql({});
         expect(c.something.anything.name).to.eql('b');
         expect(c.something.anything.arr).to.eql([4, 5, 6]);
+    });
+});
+describe('circular configuratoror', function () {
+    it('throws an error on circular dependencies', function () {
+        assert.throws(function () {
+            configuratoror({ folder: './test/circular_config' });
+        }, Error, 'circular dependencies detected in chain ["e","f","d"]');
     });
 });


### PR DESCRIPTION
The process no longer hangs in an infinite loop when including an infinite circle. An error is thrown showing what chain caused the circle.
It works by simply walking the chain untill either a loop is found or no more config._extends.

Added mocha test for asserting the thrown Error
Updated README.md to reflect the changes
